### PR TITLE
Dev

### DIFF
--- a/R/skm.r
+++ b/R/skm.r
@@ -388,3 +388,5 @@ loadModule("skm_module", TRUE)
 # protect from using all thread when run skmRpl parallel
 # setThreadOptions(numThreads = defaultNumThreads() / 2)
 #------------------------------------------------------------------------------#
+
+#


### PR DESCRIPTION
* a faster version of skm::skm_gdp_cpp (with >5X speed up)
* a greedy algorithm different from skm::skm_gdp_cpp

test cases to justify the equivalence between` skm::skm_gdp_cpp` and `skm_greedy`, and also justify the new greedy algorithm `cwsc`
```
library(data.table)

weight <- matrix(c(1,1,1,1,1,1,0,0,10,10,10,10,10,10,0,0,0,0), nrow = 3, byrow = T)

m1 <- skm::skm_gdp_cpp(
  x = weight, k = 2L
)

m2 <- skm_greedy(
  x = weight, k = 2L
)

m3 <- cwsc(
  x = weight, k = 2L
)


sum(apply(weight[m1 + 1L, ], 2L, min))
sum(apply(weight[m2 + 1L, ], 2L, min))
sum(apply(weight[m3 + 1L, ], 2L, min))
```